### PR TITLE
Fixes Unused Component Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "parserOptions": {
       "parser": "@babel/eslint-parser"
     },
-    "rules": {}
+    "rules": {"vue/no-unused-components": "off"}
   },
   "browserslist": [
     "> 1%",

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,7 +27,6 @@
       />
     </div>
     <div class="footerContainer"><p>CREATED 2022 BY TEAM 3</p></div>
-    <CourseItem style="display: none"></CourseItem>
   </div>
 </template>
 


### PR DESCRIPTION
With the way we dynamically add CourseItem components to our page, the Vue linter didn't like that we imported a component but didn't use it immediately. At present, we just had a hidden CourseItem on the page, but this isn't great as it threw some errors and is just generally not a great solution.

 There is a way around this, but it would take refactoring the entire App.vue file, so instead I just turned off the "no-unused-components" rule in the package.json. This is *not* an ideal solution, but given our limited time left, it's the best one.